### PR TITLE
Add Claude marketplace.json to repo root

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,28 @@
+{
+  "name": "isambard-skills",
+  "owner": {
+    "name": "Isambard SC",
+    "email": "support@isambard.ac.uk"
+  },
+  "metadata": {
+    "description": "AI agent skills for Isambard HPC systems",
+    "version": "1.0"
+  },
+  "plugins": [
+    {
+      "name": "isambard",
+      "description": "AI agent skills for Isambard HPC systems",
+      "version": "1.0",
+      "author": {
+        "name": "Isambard SC"
+      },
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/isambard-sc/skills.isambard.ac.uk.git",
+        "path": "site/plugins/isambard"
+      },
+      "homepage": "https://skills.isambard.ac.uk",
+      "repository": "https://github.com/isambard-sc/skills.isambard.ac.uk"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,11 +16,7 @@
       "author": {
         "name": "Isambard SC"
       },
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/isambard-sc/skills.isambard.ac.uk.git",
-        "path": "site/plugins/isambard"
-      },
+      "source": "site/plugins/isambard",
       "homepage": "https://skills.isambard.ac.uk",
       "repository": "https://github.com/isambard-sc/skills.isambard.ac.uk"
     }

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the environment from scratch every session.
 Add the Isambard marketplace (all skills at once):
 
 ```
-/plugin marketplace add https://skills.isambard.ac.uk/.claude-plugin/marketplace.json
+/plugin marketplace add https://github.com/isambard-sc/skills.isambard.ac.uk
 ```
 
 Install Isambard plugin:
@@ -99,7 +99,9 @@ raw Markdown content is served directly from this site.
 ## Repository Structure
 
 ```
-site/plugins/isambard/                      # All web-served content (GitHub Pages source)
+.claude-plugin
+  marketplace.json           # Claude Code plugin marketplace catalog
+site/plugins/isambard/       # All web-served content (GitHub Pages source)
   .claude-plugin/
     marketplace.json         # Claude Code plugin marketplace catalog
   skills/


### PR DESCRIPTION
`/plugin marketplace add` looks for `.claude-plugin` folder at repo root.