### PR TITLE
Add service-status and docs-navigation skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ the environment from scratch every session.
 | [MPI](site/plugins/isambard/skills/mpi/SKILL.md) | Use MPI on Isambard with Cray MPICH or OpenMPI. Covers PMI types, srun --mpi flags, Slingshot 11 performance, and why mpirun/mpiexec must not be used | `https://skills.isambard.ac.uk/skills/mpi/SKILL.md` |
 | [NCCL](site/plugins/isambard/skills/nccl/SKILL.md) | Use NCCL for multi-node GPU communication on Isambard-AI over Slingshot 11. Covers the brics/nccl module, aws-ofi-nccl plugin, building from source, and NCCL in containers | `https://skills.isambard.ac.uk/skills/nccl/SKILL.md` |
 | [GPUs and CUDA](site/plugins/isambard/skills/cuda/SKILL.md) | Use GPUs and CUDA on Isambard-AI (NVIDIA GH200, sm_90). Covers cudatoolkit/nvhpc modules, compiling with nvcc, and CUDA forward compatibility via NGC containers or NVIDIA HPC SDK | `https://skills.isambard.ac.uk/skills/cuda/SKILL.md` |
+| [Docs Navigation](site/plugins/isambard/skills/docs-navigation/SKILL.md) | Locate the correct page on docs.isambard.ac.uk for any Isambard question and answer from the live page instead of memory. Includes a topic-to-URL map and a stdlib Python page fetcher | `https://skills.isambard.ac.uk/plugins/isambard/skills/docs-navigation/SKILL.md` |
+| [Service Status](site/plugins/isambard/skills/service-status/SKILL.md) | Check the live operational status of Isambard facilities (overview, known issues, planned maintenance) and report recent platform changes from the docs site and isambard-sc GitHub | `https://skills.isambard.ac.uk/plugins/isambard/skills/service-status/SKILL.md` |
 
 ---
 

--- a/site/index.html
+++ b/site/index.html
@@ -148,6 +148,16 @@
       </div>
 
       <div class="skill-card">
+        <h3>Docs Navigation</h3>
+        <p>
+          Locate the correct page on docs.isambard.ac.uk for any Isambard
+          question and answer from the live page instead of memory. Includes
+          a topic-to-URL map of the documentation site.
+        </p>
+        <a href="plugins/isambard/skills/docs-navigation/SKILL.md">View skill file &rarr;</a>
+      </div>
+
+      <div class="skill-card">
         <h3>GPUs and CUDA</h3>
         <p>
           Use GPUs and CUDA on Isambard-AI (NVIDIA GH200, sm_90). Covers
@@ -194,6 +204,16 @@
           mpi4py.
         </p>
         <a href="plugins/isambard/skills/python/SKILL.md">View skill file &rarr;</a>
+      </div>
+
+      <div class="skill-card">
+        <h3>Service Status</h3>
+        <p>
+          Check the live operational status of Isambard facilities — status
+          overview, known issues, planned maintenance — and report recent
+          platform changes from the docs site and isambard-sc GitHub.
+        </p>
+        <a href="plugins/isambard/skills/service-status/SKILL.md">View skill file &rarr;</a>
       </div>
 
       <div class="skill-card">

--- a/site/marketplace.json
+++ b/site/marketplace.json
@@ -42,6 +42,16 @@
       "name": "GPUs and CUDA",
       "description": "Use GPUs and CUDA on Isambard-AI (NVIDIA GH200, sm_90). Covers loading cudatoolkit/nvhpc modules, compiling with nvcc -arch=sm_90, and CUDA forward compatibility for newer CUDA versions via NGC containers, NVIDIA HPC SDK, or conda cuda-compat.",
       "url": "https://skills.isambard.ac.uk/plugins/isambard/skills/cuda/SKILL.md"
+    },
+    {
+      "name": "Docs Navigation",
+      "description": "Locate the correct page on docs.isambard.ac.uk for any Isambard question and answer from the live page instead of memory. Includes a topic-to-URL map of the documentation site and a stdlib Python page fetcher.",
+      "url": "https://skills.isambard.ac.uk/plugins/isambard/skills/docs-navigation/SKILL.md"
+    },
+    {
+      "name": "Service Status",
+      "description": "Check the live operational status of Isambard facilities (status overview, known issues, planned maintenance) and report recent platform changes (docs updates, isambard-sc GitHub activity and releases). Never answers status questions from memory.",
+      "url": "https://skills.isambard.ac.uk/plugins/isambard/skills/service-status/SKILL.md"
     }
   ]
 }

--- a/site/plugins/isambard/skills/docs-navigation/SKILL.md
+++ b/site/plugins/isambard/skills/docs-navigation/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: docs-navigation
+description: >
+  Locate the correct page on docs.isambard.ac.uk for any Isambard question
+  and answer from the live page instead of memory. Use this skill whenever a
+  user asks how to do something on Isambard-AI or Isambard 3 — getting
+  access, logging in (clifton/SSH), transferring files, storage and quotas,
+  Jupyter, VS Code, project management, accounting, applications, policies,
+  training — and no more specific Isambard skill covers it, or whenever an
+  answer should cite official Isambard documentation.
+compatibility: >
+  Requires outbound HTTPS. Works with any web-fetch tool; a stdlib Python
+  fetcher is bundled for agents without one.
+metadata:
+  author: Shiran
+  version: "1.0"
+  source_url: https://docs.isambard.ac.uk/
+---
+
+# Docs Navigation — Agent Skill
+
+Full documentation: <https://docs.isambard.ac.uk/>
+
+## ⚠️ Critical Rules
+
+- **Answer from the live page, not from memory.** Generic HPC knowledge is
+  often wrong here: Isambard-AI and Isambard 3 Grace are aarch64/Arm64,
+  use clifton for SSH access, and have site-specific Slurm limits.
+- Cite the exact `docs.isambard.ac.uk` URL for every substantive claim.
+- Quote commands, module names, partition names, and paths **verbatim from
+  the fetched page** — do not invent or "correct" them.
+- Prefer a more specific installed Isambard skill (slurm, python,
+  containers, mpi, nccl, cuda, spack, modules, service-status) when one
+  matches the question; use this skill for everything else and for finding
+  canonical links.
+- If a mapped path returns 404, re-check
+  <https://docs.isambard.ac.uk/sitemap.xml> — the site may have been
+  restructured — and answer from the current location.
+
+## Overview
+
+`docs.isambard.ac.uk` is the canonical documentation for the Bristol
+Centre for Supercomputing (BriCS) facilities: Isambard-AI (GH200, aarch64),
+Isambard 3 Grace (Arm CPU), Isambard 3 MACS (multi-architecture), and
+BlueCrystal 5 early access. The site has ~95 pages;
+`references/url-map.md` maps question topics to exact page URLs.
+
+## How to answer a documentation question
+
+1. Pick the single best-matching page in `references/url-map.md`.
+2. Fetch it — with the available web-fetch tool, or the bundled fallback:
+
+   ```bash
+   python3 scripts/fetch_page.py user-documentation/guides/login/
+   ```
+
+3. Answer from the fetched content and cite the URL. If the page defers to
+   another guide, fetch that guide too rather than guessing.
+
+## Common Issues
+
+- **No web-fetch tool available**: `scripts/fetch_page.py` needs only
+  Python 3.8+ and prints the page as plain text with its `Last-Modified`
+  header.
+- **Question spans several pages** (e.g. "train a model" = login + storage
+  + python + slurm): fetch each relevant page; do not stitch an answer from
+  memory.
+- **Status-related questions** ("is it down?", maintenance): use the
+  `service-status` skill instead — status must never be answered from
+  static content.
+
+## Further Reading
+
+- Documentation home: <https://docs.isambard.ac.uk/>
+- Getting started:
+  <https://docs.isambard.ac.uk/user-documentation/getting_started/>
+- Getting support: <https://docs.isambard.ac.uk/getting_support/>
+- AI-agent usage policy:
+  <https://docs.isambard.ac.uk/user-documentation/guides/using_ai_agents/>

--- a/site/plugins/isambard/skills/docs-navigation/references/url-map.md
+++ b/site/plugins/isambard/skills/docs-navigation/references/url-map.md
@@ -1,0 +1,117 @@
+# docs.isambard.ac.uk URL map
+
+Pick the ONE page that best matches the question, fetch it, and answer from
+it. All paths are relative to `https://docs.isambard.ac.uk`. If a path
+returns 404, re-check `https://docs.isambard.ac.uk/sitemap.xml`.
+
+## Start here / orientation
+
+- `/` — landing page and top-level navigation
+- `/user-documentation/getting_started/` — first steps once access is
+  granted (accounts, portal, first login)
+- `/user-documentation/tutorials/setup/` — end-to-end setup tutorial:
+  clifton install, auth, SSH config, first job
+- `/user-documentation/tutorials/intro-tour/` — guided tour for new users
+- `/user-documentation/information/how-isambard-works/` — architecture:
+  login vs compute nodes, how the pieces fit together
+- `/specs/` — hardware specs: GH200 nodes, Grace nodes, MACS, interconnect
+- `/user-documentation/faqs/` — FAQ index
+  (`/user-documentation/faqs/bc5-launch/` for BlueCrystal 5)
+
+## Access & projects
+
+- `/access/` — how to apply for time on Isambard
+- `/user-documentation/information/portals/` — the web portals and what
+  each is for
+- `/user-documentation/guides/awards_portal/` — awards/allocation portal
+- `/user-documentation/guides/manage_project/` — PI tasks: adding members,
+  managing the project
+- `/user-documentation/guides/follow_on_project/` — follow-on projects
+- `/user-documentation/guides/accounting/` — GPU-hour/CPU-hour usage and
+  allocation accounting
+- `/user-documentation/guides/aws_accounts/` — linked AWS accounts
+- `/user-documentation/information/project-policies/` — project lifecycle,
+  data retention at project end
+
+## Connecting & transferring data
+
+- `/user-documentation/guides/login/` — SSH login via clifton
+  (certificates valid 12 h → `clifton auth` daily)
+- `/user-documentation/guides/shortname/` — setting the UNIX short name
+- `/user-documentation/guides/mobaxterm/` — Windows / MobaXterm setup
+- `/user-documentation/guides/file_transfer/` — scp/rsync data transfer
+- `/user-documentation/tutorials/data-mover/` — data-mover nodes for large
+  transfers
+- `/user-documentation/guides/vscode/` — VS Code Remote-SSH
+- `/user-documentation/guides/jupyter/` — Jupyter on compute nodes
+- `/user-documentation/guides/jupyterhub/` — the BriCS JupyterHub service
+
+## Jobs & scheduling (Slurm)
+
+- `/user-documentation/guides/slurm/` — Slurm basics; `--gpus` is required
+  on Isambard-AI
+- `/user-documentation/guides/slurm-examples/` — ready-made job scripts
+- `/user-documentation/guides/slurm-advanced/` — arrays, dependencies,
+  chaining jobs beyond 24 h, job steps
+- `/user-documentation/guides/slurm-troubleshooting/` — pending/failed
+  jobs, common Slurm errors
+- `/user-documentation/information/job-scheduling/` — partitions, QoS,
+  walltime and GPU limits, fair-share
+- `/user-documentation/guides/argo-workflows/` — Argo Workflows service
+
+## Storage
+
+- `/user-documentation/information/system-storage/` — `$HOME`,
+  `$SCRATCHDIR`, `$PROJECTDIR`, `$LOCALDIR`, quotas, retention
+- `/user-documentation/tutorials/datasets-in-squashfs/` — packing
+  many-file datasets into SquashFS
+
+## Software environments
+
+- `/user-documentation/guides/modules/` — module system, Cray PrgEnv,
+  compiler wrappers
+- `/user-documentation/guides/environment_variables/` — predefined
+  environment variables
+- `/user-documentation/guides/python/` — Miniforge/conda, uv, venvs,
+  aarch64 wheel pitfalls
+- `/user-documentation/guides/spack/` (and `spack/setup/`) — building
+  software with Spack and the buildit configs
+- `/user-documentation/guides/e4s/` — E4S software stack
+- `/user-documentation/guides/containers/` — Podman-HPC vs Apptainer
+  overview (single/multi-node pages live under this path)
+- `/user-documentation/guides/gpus_and_cuda/` — CUDA toolkits, sm_90,
+  forward compatibility
+- `/user-documentation/guides/mpi/` — Cray MPICH/OpenMPI, `srun --mpi`
+- `/user-documentation/guides/nccl/` — NCCL over Slingshot 11
+- `/user-documentation/guides/using_ai_agents/` — policy and guidance for
+  using AI agents with Isambard
+
+## ML & applications
+
+- `/user-documentation/applications/ML-packages/` — PyTorch/JAX/TensorFlow
+  on GH200
+- `/user-documentation/tutorials/distributed-training/` — multi-node
+  distributed PyTorch
+- `/user-documentation/tutorials/distributed-inference/` — multi-node vLLM
+- `/user-documentation/tutorials/interactive-ml/` — interactive ML session
+- `/user-documentation/applications/alphafold/` — AlphaFold (see also
+  `/user-documentation/tutorials/interactive-alphafold/`)
+- `/user-documentation/applications/relion/` — Relion (cryo-EM)
+- `/user-documentation/applications/orca/` — ORCA (quantum chemistry)
+
+## Service status (use the service-status skill)
+
+- `/service-status/` — current per-system status overview
+- `/service-status/known_issues/` — active known issues
+- `/service-status/planned_maintenance/` — upcoming maintenance windows
+- `/service-status/archived_issues/` — resolved past issues
+
+## Support, policies, misc
+
+- `/getting_support/` — how to raise a ticket
+- `/policies/` — acceptable use, access terms, privacy, licensing,
+  resource management, shared responsibility
+- `/acknowledge/` — acknowledging Isambard in publications
+- `/training/` — training events (materials under `/training/<event>/`)
+- `/events/` — Isambard Summit and open days
+- `/about/` — about the documentation site

--- a/site/plugins/isambard/skills/docs-navigation/scripts/fetch_page.py
+++ b/site/plugins/isambard/skills/docs-navigation/scripts/fetch_page.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Print a docs.isambard.ac.uk page as plain text.
+
+Fallback fetcher for agents without a web-fetch tool. Usage:
+
+    python3 fetch_page.py <url-or-path>
+    python3 fetch_page.py user-documentation/guides/slurm/
+
+Standard library only; requires outbound HTTPS.
+
+@author Shiran
+"""
+import re
+import sys
+import urllib.request
+from html.parser import HTMLParser
+
+BASE = "https://docs.isambard.ac.uk/"
+
+
+class ArticleText(HTMLParser):
+    """Reduce a MkDocs <article> block to readable plain text."""
+
+    SKIP = {"script", "style", "nav", "footer", "aside"}
+
+    def __init__(self):
+        super().__init__()
+        self.parts = []
+        self.skip = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self.SKIP:
+            self.skip += 1
+        elif tag in ("h1", "h2", "h3", "h4", "h5"):
+            self.parts.append("\n\n" + "#" * int(tag[1]) + " ")
+        elif tag == "li":
+            self.parts.append("\n- ")
+        elif tag in ("p", "tr", "br", "pre"):
+            self.parts.append("\n")
+        elif tag in ("td", "th"):
+            self.parts.append(" | ")
+
+    def handle_endtag(self, tag):
+        if tag in self.SKIP and self.skip:
+            self.skip -= 1
+
+    def handle_data(self, data):
+        if not self.skip:
+            self.parts.append(data)
+
+
+def fetch_page(url):
+    """Return (plain_text, last_modified) for a docs page."""
+    req = urllib.request.Request(url, headers={"User-Agent": "isambard-skill"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        html = resp.read().decode("utf-8", "replace")
+        last_modified = resp.headers.get("Last-Modified", "unknown")
+    match = re.search(r"<article[^>]*>(.*?)</article>", html, re.S)
+    parser = ArticleText()
+    parser.feed(match.group(1) if match else html)
+    text = "".join(parser.parts).replace("¶", "")
+    lines = [re.sub(r"[ \t]+", " ", ln).strip() for ln in text.splitlines()]
+    collapsed = "\n".join(lines)
+    return re.sub(r"\n{3,}", "\n\n", collapsed).strip(), last_modified
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit(__doc__)
+    target = sys.argv[1]
+    url = target if target.startswith("http") else BASE + target.lstrip("/")
+    if not url.endswith(("/", ".xml", ".txt", ".html")):
+        url += "/"
+    try:
+        text, last_modified = fetch_page(url)
+    except Exception as exc:
+        sys.exit(f"FETCH FAILED for {url}: {exc}")
+    print(f"SOURCE: {url}")
+    print(f"LAST-MODIFIED: {last_modified}")
+    print("-" * 72)
+    print(text or "(no content extracted — read the URL directly)")
+
+
+if __name__ == "__main__":
+    main()

--- a/site/plugins/isambard/skills/service-status/SKILL.md
+++ b/site/plugins/isambard/skills/service-status/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: service-status
+description: >
+  Check the LIVE operational status of Isambard facilities and report recent
+  platform changes. Use this skill whenever a user asks whether Isambard-AI,
+  Isambard 3 (Grace or MACS), or BlueCrystal 5 is down, degraded, or in
+  maintenance, reports login failures or unexpected job problems, asks about
+  known issues, outages, or upcoming maintenance windows, or asks what
+  changed recently (documentation updates, new clifton releases, isambard-sc
+  GitHub activity). Always run the bundled scripts to fetch live pages —
+  never answer service-status questions from memory or training data.
+compatibility: >
+  Runs on the user's local machine with Python 3.8+ and outbound HTTPS
+  (standard library only). Does not require access to an Isambard login
+  node.
+metadata:
+  author: Shiran
+  version: "1.0"
+  source_url: https://docs.isambard.ac.uk/service-status/
+  supplementary_urls:
+    - https://docs.isambard.ac.uk/service-status/known_issues/
+    - https://docs.isambard.ac.uk/service-status/planned_maintenance/
+    - https://docs.isambard.ac.uk/service-status/archived_issues/
+---
+
+# Service Status — Agent Skill
+
+Full documentation: <https://docs.isambard.ac.uk/service-status/>
+
+## ⚠️ Critical Rules
+
+- **Never report Isambard service status from memory or training data.**
+  Run `scripts/check_status.py` (or fetch the status pages directly) on
+  every status question, every time.
+- Always state the source URL and the page's `Last-Modified` time in the
+  answer, so the user knows how fresh the information is.
+- If the live fetch fails, report the status as **UNKNOWN** and give the
+  user the URL to check — do not guess or assume "no known issues".
+- When a user reports an error (login failure, job stuck, service
+  unreachable), check known issues **before** starting to debug — many
+  reported "bugs" are documented outages.
+- Treat maintenance windows as UK time (Europe/London) unless the page
+  states otherwise.
+- The unauthenticated GitHub API allows 60 requests/hour per IP. Do not
+  call `check_updates.py` in a loop; set `GITHUB_TOKEN` if it returns 403.
+
+## Overview
+
+The authoritative status source is the service-status section of
+`docs.isambard.ac.uk` (`status.isambard.ac.uk` redirects there; there is
+no separate status platform and no JSON status API). It reports a
+plain-text status per facility — Isambard-AI, Isambard 3 Grace, Isambard 3
+MACS, and BlueCrystal 5 — plus known-issues and planned-maintenance pages.
+
+Pages sit behind a CDN cache of up to ~10 minutes; the `Last-Modified`
+HTTP header is the honest freshness signal and both scripts print it.
+
+## Check current status
+
+```bash
+python3 scripts/check_status.py          # overview + known issues + maintenance
+python3 scripts/check_status.py --all    # also include archived (resolved) issues
+```
+
+Report status **per system** and name the system the user cares about
+explicitly. Quote the relevant status text rather than paraphrasing labels.
+
+## Check recent updates
+
+```bash
+python3 scripts/check_updates.py --days 14
+```
+
+Reports, in one pass:
+
+- when the docs site was last redeployed (`Last-Modified`),
+- documentation pages added or removed since the previous run (sitemap
+  diff, cached under `~/.cache/isambard-service-status/`),
+- `isambard-sc` GitHub repositories pushed within the window, their recent
+  commits, and the latest releases of key user-facing repositories
+  (clifton, skills.isambard.ac.uk, buildit).
+
+The sitemap diff cannot detect content changes inside an existing page —
+say so if the user asks whether a specific page changed.
+
+## Common Issues
+
+- **Script cannot reach the network**: fetch
+  <https://docs.isambard.ac.uk/service-status/> with a web tool instead,
+  and mention which method was used.
+- **GitHub section returns 403**: unauthenticated rate limit exhausted;
+  export `GITHUB_TOKEN` and re-run.
+- **First run of `check_updates.py`**: the sitemap is only being cached,
+  so no page diff is available until the next run.
+
+## Further Reading
+
+- Service status: <https://docs.isambard.ac.uk/service-status/>
+- Known issues: <https://docs.isambard.ac.uk/service-status/known_issues/>
+- Planned maintenance:
+  <https://docs.isambard.ac.uk/service-status/planned_maintenance/>
+- Getting support: <https://docs.isambard.ac.uk/getting_support/>

--- a/site/plugins/isambard/skills/service-status/scripts/check_status.py
+++ b/site/plugins/isambard/skills/service-status/scripts/check_status.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fetch the live Isambard service status from docs.isambard.ac.uk.
+
+Prints the status overview, known issues, and planned maintenance as plain
+text, each with the page's Last-Modified header. Pass --all to include
+archived (resolved) issues. Exits non-zero if any page could not be fetched.
+
+Standard library only; requires outbound HTTPS.
+
+@author Shiran
+"""
+import re
+import sys
+import urllib.request
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+
+BASE = "https://docs.isambard.ac.uk/service-status/"
+PAGES = [
+    ("SERVICE STATUS OVERVIEW", BASE),
+    ("KNOWN ISSUES", BASE + "known_issues/"),
+    ("PLANNED MAINTENANCE", BASE + "planned_maintenance/"),
+]
+ARCHIVE = ("ARCHIVED ISSUES (resolved)", BASE + "archived_issues/")
+
+
+class ArticleText(HTMLParser):
+    """Reduce a MkDocs <article> block to readable plain text."""
+
+    SKIP = {"script", "style", "nav", "footer", "aside"}
+
+    def __init__(self):
+        super().__init__()
+        self.parts = []
+        self.skip = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self.SKIP:
+            self.skip += 1
+        elif tag in ("h1", "h2", "h3", "h4", "h5"):
+            self.parts.append("\n\n" + "#" * int(tag[1]) + " ")
+        elif tag == "li":
+            self.parts.append("\n- ")
+        elif tag in ("p", "tr", "br", "pre"):
+            self.parts.append("\n")
+        elif tag in ("td", "th"):
+            self.parts.append(" | ")
+
+    def handle_endtag(self, tag):
+        if tag in self.SKIP and self.skip:
+            self.skip -= 1
+
+    def handle_data(self, data):
+        if not self.skip:
+            self.parts.append(data)
+
+
+def fetch_page(url):
+    """Return (plain_text, last_modified) for a docs page."""
+    req = urllib.request.Request(url, headers={"User-Agent": "isambard-skill"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        html = resp.read().decode("utf-8", "replace")
+        last_modified = resp.headers.get("Last-Modified", "unknown")
+    match = re.search(r"<article[^>]*>(.*?)</article>", html, re.S)
+    parser = ArticleText()
+    parser.feed(match.group(1) if match else html)
+    text = "".join(parser.parts).replace("¶", "")
+    lines = [re.sub(r"[ \t]+", " ", ln).strip() for ln in text.splitlines()]
+    collapsed = "\n".join(lines)
+    return re.sub(r"\n{3,}", "\n\n", collapsed).strip(), last_modified
+
+
+def main():
+    pages = PAGES + [ARCHIVE] if "--all" in sys.argv[1:] else PAGES
+    print(f"Fetched at: {datetime.now(timezone.utc):%Y-%m-%d %H:%M UTC}")
+    print("Note: pages may be CDN-cached for up to ~10 minutes.\n")
+    failures = 0
+    for title, url in pages:
+        print("=" * 72)
+        print(f"{title}  <{url}>")
+        try:
+            text, last_modified = fetch_page(url)
+            print(f"Page last modified: {last_modified}")
+            print("=" * 72)
+            print(text or "(no content extracted — read the URL directly)")
+        except Exception as exc:
+            failures += 1
+            print("=" * 72)
+            print(f"FETCH FAILED: {exc}")
+            print("Report status as UNKNOWN and point the user at the URL.")
+        print()
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/site/plugins/isambard/skills/service-status/scripts/check_updates.py
+++ b/site/plugins/isambard/skills/service-status/scripts/check_updates.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Report recent Isambard platform changes.
+
+Covers the docs site (last deploy time, pages added/removed since the
+previous run) and the isambard-sc GitHub organisation (repositories pushed
+within the window, recent commits, latest releases of key user-facing
+repositories). Usage:
+
+    python3 check_updates.py [--days N]      # default 14
+
+Standard library only. Uses the unauthenticated GitHub API (60 requests per
+hour per IP); set GITHUB_TOKEN to raise the limit.
+
+@author Shiran
+"""
+import json
+import os
+import re
+import sys
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+DOCS = "https://docs.isambard.ac.uk/"
+ORG = "isambard-sc"
+KEY_RELEASE_REPOS = ("clifton", "skills.isambard.ac.uk", "buildit")
+CACHE_DIR = Path.home() / ".cache" / "isambard-service-status"
+MAX_REPOS_DETAILED = 6
+
+
+def http_get(url):
+    headers = {"User-Agent": "isambard-skill"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token and url.startswith("https://api.github.com/"):
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read().decode("utf-8", "replace"), resp.headers
+
+
+def gh_json(url):
+    body, _ = http_get(url)
+    return json.loads(body)
+
+
+def report_docs():
+    print("=" * 72)
+    print(f"DOCS SITE  <{DOCS}>")
+    print("=" * 72)
+    try:
+        # the homepage omits Last-Modified; sub-pages carry the deploy time
+        _, headers = http_get(DOCS + "service-status/")
+        print(f"Site last deployed: {headers.get('Last-Modified', 'unknown')}")
+    except Exception as exc:
+        print(f"Could not fetch site: {exc}")
+
+    try:
+        sitemap, _ = http_get(DOCS + "sitemap.xml")
+        urls = sorted(set(re.findall(r"<loc>(.*?)</loc>", sitemap)))
+        print(f"Pages in sitemap: {len(urls)}")
+        cache = CACHE_DIR / "sitemap-urls.txt"
+        if cache.exists():
+            previous = set(cache.read_text().splitlines())
+            for url in (u for u in urls if u not in previous):
+                print(f"  + added:   {url}")
+            for url in sorted(previous.difference(urls)):
+                print(f"  - removed: {url}")
+            if previous == set(urls):
+                print("No pages added or removed since the last check "
+                      "(content edits inside existing pages are not "
+                      "detectable).")
+        else:
+            print("First run — sitemap cached; future runs will diff it.")
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        cache.write_text("\n".join(urls))
+    except Exception as exc:
+        print(f"Could not process sitemap: {exc}")
+    print()
+
+
+def report_github(days):
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    print("=" * 72)
+    print(f"GITHUB org {ORG} — activity in the last {days} days")
+    print("=" * 72)
+    try:
+        repos = gh_json(
+            f"https://api.github.com/orgs/{ORG}/repos?sort=pushed&per_page=100"
+        )
+    except Exception as exc:
+        print(f"GitHub API failed: {exc}")
+        print(f"Fallback: https://github.com/{ORG}/<repo>/commits/main.atom")
+        return
+
+    def pushed_at(repo):
+        return datetime.strptime(
+            repo["pushed_at"], "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=timezone.utc)
+
+    active = [r for r in repos if r.get("pushed_at") and pushed_at(r) >= since]
+    if not active:
+        print("No repositories pushed in this window.")
+    for repo in active[:MAX_REPOS_DETAILED]:
+        print(f"--- {repo['full_name']}  (pushed {repo['pushed_at']})")
+        if repo.get("description"):
+            print(f"    {repo['description']}")
+        try:
+            commits = gh_json(
+                f"https://api.github.com/repos/{repo['full_name']}/commits"
+                f"?since={since:%Y-%m-%dT%H:%M:%SZ}&per_page=10"
+            )
+            for commit in commits:
+                date = commit["commit"]["author"]["date"][:10]
+                message = commit["commit"]["message"].splitlines()[0][:90]
+                print(f"    {date}  {commit['sha'][:7]}  {message}")
+            if not commits:
+                print("    (no commits on the default branch in this window)")
+        except Exception as exc:
+            print(f"    commits unavailable: {exc}")
+        print()
+    skipped = active[MAX_REPOS_DETAILED:]
+    if skipped:
+        print("Not detailed (rate-limit budget): "
+              + ", ".join(r["name"] for r in skipped) + "\n")
+
+    print("--- Latest releases of key user-facing repositories")
+    for name in KEY_RELEASE_REPOS:
+        try:
+            release = gh_json(
+                f"https://api.github.com/repos/{ORG}/{name}/releases/latest"
+            )
+            print(f"    {name}: {release.get('tag_name')} "
+                  f"({(release.get('published_at') or '')[:10]}) — "
+                  f"{release.get('html_url')}")
+        except Exception:
+            print(f"    {name}: no releases")
+
+
+def main():
+    args = sys.argv[1:]
+    days = 14
+    if "--days" in args:
+        try:
+            days = int(args[args.index("--days") + 1])
+        except (IndexError, ValueError):
+            sys.exit("Usage: python3 check_updates.py [--days N]")
+    print(f"Checked at: {datetime.now(timezone.utc):%Y-%m-%d %H:%M UTC}\n")
+    report_docs()
+    report_github(days)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds two skills to the `isambard` plugin that route agents to **live sources** rather than static content:

- **service-status** — check the live operational status of Isambard facilities (status overview, known issues, planned maintenance), and report recent platform changes: docs-site deploys, sitemap page additions/removals, and `isambard-sc` GitHub activity and releases.
- **docs-navigation** — locate the correct page on docs.isambard.ac.uk for any question via a topic-to-URL map covering the full sitemap (~93 pages), fetch the live page, and answer with a citation. Includes a stdlib-only fallback fetcher for agents without a built-in web-fetch tool.

## Motivation

The existing skills carry the task knowledge, but agents still tend to answer "is Isambard down?" from training-data memory. Status questions need live data: `status.isambard.ac.uk` redirects to the docs service-status pages and there is no JSON status API, so these skills fetch the pages directly and require the agent to cite the source URL and `Last-Modified` time in every answer. The navigation skill complements the task skills by covering the long tail of documentation topics (access, portals, storage, file transfer, Jupyter, policies, …) without duplicating content that would go stale.

## Changes

Per `.github/agents/skills-agent.md`:

- `site/plugins/isambard/skills/service-status/` — `SKILL.md` + `scripts/check_status.py` + `scripts/check_updates.py`
- `site/plugins/isambard/skills/docs-navigation/` — `SKILL.md` + `references/url-map.md` + `scripts/fetch_page.py`
- Registered both skills in `site/marketplace.json`, added cards to `site/index.html` (alphabetical order preserved), and appended rows to the README skills table
- `plugin.json` untouched (skill auto-discovery)

The diff is purely additive — no existing content is modified. Scripts require Python 3.8+ standard library only, no third-party dependencies, and respect the unauthenticated GitHub API rate limit (honouring `GITHUB_TOKEN` when set).

## Testing

- All three scripts run successfully against the live site (service-status pages, sitemap.xml, GitHub API) and print sensible output for the current MACS/BlueCrystal 5 outages
- `python3 -m py_compile` passes on all scripts
- All marketplace/plugin JSON files parse
- `SKILL.md` frontmatter parses with PyYAML; `name` matches the directory name; descriptions are within the 1024-character limit

## Notes

- The new README/marketplace entries use the `https://skills.isambard.ac.uk/plugins/isambard/skills/<name>/SKILL.md` URL form, since the `…/skills/<name>/SKILL.md` form documented in the agent instructions currently returns 404. Existing rows were left untouched — happy to align them in a follow-up if you'd like.
